### PR TITLE
fix: run the commit-msg hook with pnpm, not yarn

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,2 +1,2 @@
 #!/bin/sh
-yarn commitlint --edit $1
+pnpm exec commitlint --edit $1


### PR DESCRIPTION
The pnpm conversion left `.husky/commit-msg` invoking **yarn**:

```sh
yarn commitlint --edit $1
```

Yarn 1.22 then refuses to run at all, because `packageManager` names pnpm — it reports the field back mangled as `yarn@pnpm@11.20.0`, which reads like a corrupt `package.json` and sends you looking in the wrong file. The `package.json` is fine.

This is not cosmetic: `changesets/action` commits the version bump with `git commit`, so the hook runs **inside the release job**. On `semantic-release-bamboo` it took the whole release down after `changeset version` had already succeeded.

`pnpm exec commitlint` is the equivalent that resolves the local binary.